### PR TITLE
Fix include dependencies in client utilities

### DIFF
--- a/src/client_utils.cpp
+++ b/src/client_utils.cpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <mutex>
 #include <random>
+#include <sstream>
+#include <iomanip>
 #include <string>
 #include <thread>
 #include <utility>

--- a/src/client_utils.hpp
+++ b/src/client_utils.hpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "Inference_queue.hpp"
-#include "client_utils.hpp"
 #include "inference_runner.hpp"
 #include "input_generator.hpp"
 #include "logger.hpp"


### PR DESCRIPTION
## Summary
- add missing `<sstream>` and `<iomanip>` includes
- remove accidental self-include and ensure newline at end of `client_utils.hpp`

## Testing
- `cmake ..` *(fails: Torch not found)*

------
https://chatgpt.com/codex/tasks/task_e_684484823b988323bec16348ee58ad38