### PR TITLE
Implement queue capacity limit

### DIFF
--- a/src/core/warmup.cpp
+++ b/src/core/warmup.cpp
@@ -77,7 +77,9 @@ WarmupRunner::client_worker(
         client_utils::log_job_enqueued(
             opts_, job_id, total, job->timing_info().enqueued_time);
 
-        queue.push(job);
+        if (!queue.push(job)) {
+          log_warning("Warmup job dropped due to full queue.");
+        }
         job_id++;
       }
     }
@@ -97,7 +99,7 @@ WarmupRunner::run(unsigned int iterations_per_worker)
     return;
   }
 
-  InferenceQueue queue;
+  InferenceQueue queue(opts_.max_queue_size);
   std::atomic<unsigned int> dummy_completed_jobs = 0;
   std::mutex dummy_mutex;
   std::mutex dummy_results_mutex;

--- a/src/grpc/server/inference_service.cpp
+++ b/src/grpc/server/inference_service.cpp
@@ -103,7 +103,11 @@ InferenceServiceImpl::ModelInfer(
         result_promise.set_value(outs);
       });
 
-  queue_->push(job);
+  if (!queue_->push(job)) {
+    return Status(
+        grpc::StatusCode::RESOURCE_EXHAUSTED,
+        "Inference queue is full. Job dropped.");
+  }
   auto outputs = result_future.get();
 
   reply->set_model_name(request->model_name());

--- a/src/grpc/server/server_main.cpp
+++ b/src/grpc/server/server_main.cpp
@@ -45,7 +45,7 @@ main(int argc, char* argv[]) -> int
 
     run_warmup(opts, starpu, model_cpu, models_gpu, reference_outputs);
 
-    InferenceQueue queue;
+    InferenceQueue queue(opts.max_queue_size);
     std::vector<InferenceResult> results;
     std::mutex results_mutex;
     std::atomic<unsigned int> completed_jobs = 0;

--- a/src/utils/runtime_config.hpp
+++ b/src/utils/runtime_config.hpp
@@ -36,6 +36,9 @@ struct RuntimeConfig {
   // Logging
   VerbosityLevel verbosity = VerbosityLevel::Info;
 
+  // Queue configuration
+  size_t max_queue_size = 0;  // 0 means unlimited
+
   // Model input specifications
   std::vector<std::vector<int64_t>> input_shapes;  // Expected input shapes
   std::vector<at::ScalarType> input_types;  // Corresponding input data types


### PR DESCRIPTION
## Summary
- add `max_queue_size` field to `RuntimeConfig`
- implement capacity-aware `InferenceQueue`
- log and drop jobs when queue is full
- propagate capacity option through server components

## Testing
- `./hooks/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_684daf99a00c83238b366aa3c873e8f5