### PR TITLE
Refactor runtime config to use tensor-based I/O specs

### DIFF
--- a/models/resnet18.yml
+++ b/models/resnet18.yml
@@ -2,10 +2,10 @@ scheduler: lws
 model: ../models/resnet18.pt
 iterations: 10
 device_ids: [0]
-dims:
-  - [1, 3, 224, 224]
-types:
-  - float32
+input:
+  - { name: "input0", data_type: "TYPE_FP32", dims: [1, 3, 224, 224] }
+output:
+  - { name: "output0", data_type: "TYPE_FP32", dims: [1, 1000] }
 verbosity: "2"
 address: "0.0.0.0:50051"
 metrics_port: 9100

--- a/src/cli/args_parser.cpp
+++ b/src/cli/args_parser.cpp
@@ -246,27 +246,46 @@ parse_iterations(RuntimeConfig& opts, size_t& idx, std::span<char*> args)
 static auto
 parse_shape(RuntimeConfig& opts, size_t& idx, std::span<char*> args) -> bool
 {
-  auto& input_dims = opts.input_dims;
-  return expect_and_parse(idx, args, [&input_dims](const char* val) {
-    input_dims = {parse_shape_string(val)};
+  auto& inputs = opts.inputs;
+  return expect_and_parse(idx, args, [&inputs](const char* val) {
+    auto dims = parse_shape_string(val);
+    inputs.resize(1);
+    inputs[0].name = inputs[0].name.empty() ? "input0" : inputs[0].name;
+    inputs[0].dims = std::move(dims);
   });
 }
 
 static auto
 parse_shapes(RuntimeConfig& opts, size_t& idx, std::span<char*> args) -> bool
 {
-  auto& input_dims = opts.input_dims;
-  return expect_and_parse(idx, args, [&input_dims](const char* val) {
-    input_dims = parse_shapes_string(val);
+  auto& inputs = opts.inputs;
+  return expect_and_parse(idx, args, [&inputs](const char* val) {
+    auto dims_list = parse_shapes_string(val);
+    inputs.resize(dims_list.size());
+    for (size_t i = 0; i < dims_list.size(); ++i) {
+      inputs[i].name = inputs[i].name.empty()
+                          ? std::string("input") + std::to_string(i)
+                          : inputs[i].name;
+      inputs[i].dims = std::move(dims_list[i]);
+    }
   });
 }
 
 static auto
 parse_types(RuntimeConfig& opts, size_t& idx, std::span<char*> args) -> bool
 {
-  auto& input_types = opts.input_types;
-  return expect_and_parse(idx, args, [&input_types](const char* val) {
-    input_types = parse_types_string(val);
+  auto& inputs = opts.inputs;
+  return expect_and_parse(idx, args, [&inputs](const char* val) {
+    auto types = parse_types_string(val);
+    if (inputs.size() < types.size()) {
+      inputs.resize(types.size());
+    }
+    for (size_t i = 0; i < types.size(); ++i) {
+      inputs[i].name = inputs[i].name.empty()
+                          ? std::string("input") + std::to_string(i)
+                          : inputs[i].name;
+      inputs[i].type = types[i];
+    }
   });
 }
 
@@ -429,12 +448,25 @@ validate_config(RuntimeConfig& opts) -> void
 {
   std::vector<std::string> missing;
   check_required(!opts.model_path.empty(), "--model", missing);
-  check_required(!opts.input_dims.empty(), "--shape or --shapes", missing);
-  check_required(!opts.input_types.empty(), "--types", missing);
+  const bool have_shapes =
+      std::any_of(opts.inputs.begin(), opts.inputs.end(), [](const auto& t) {
+        return !t.dims.empty();
+      });
+  const bool have_types =
+      std::all_of(opts.inputs.begin(), opts.inputs.end(), [](const auto& t) {
+        return t.type != at::ScalarType::Undefined;
+      });
+  check_required(have_shapes, "--shape or --shapes", missing);
+  check_required(have_types, "--types", missing);
 
-  if (opts.input_dims.size() != opts.input_types.size()) {
-    log_error("Number of --types must match number of input shapes.");
-    opts.valid = false;
+  if (have_shapes && have_types) {
+    for (const auto& t : opts.inputs) {
+      if (t.dims.empty() || t.type == at::ScalarType::Undefined) {
+        log_error("Number of --types must match number of input shapes.");
+        opts.valid = false;
+        break;
+      }
+    }
   }
 
   if (!missing.empty()) {
@@ -460,8 +492,8 @@ parse_arguments(std::span<char*> args_span, RuntimeConfig opts) -> RuntimeConfig
   if (!opts.show_help) {
     validate_config(opts);
     if (opts.valid) {
-      opts.max_message_bytes = compute_max_message_bytes(
-          opts.max_batch_size, opts.input_dims, opts.input_types);
+      opts.max_message_bytes =
+          compute_max_message_bytes(opts.max_batch_size, opts.inputs);
     }
   }
 

--- a/src/core/inference_runner.cpp
+++ b/src/core/inference_runner.cpp
@@ -134,11 +134,10 @@ clone_model_to_gpus(
 // =============================================================================
 
 static auto
-generate_inputs(
-    const std::vector<std::vector<int64_t>>& dims,
-    const std::vector<torch::Dtype>& types) -> std::vector<torch::Tensor>
+generate_inputs(const std::vector<TensorConfig>& tensors)
+    -> std::vector<torch::Tensor>
 {
-  return input_generator::generate_random_inputs(dims, types);
+  return input_generator::generate_random_inputs(tensors);
 }
 
 static auto
@@ -185,7 +184,7 @@ load_model_and_reference_output(const RuntimeConfig& opts)
     auto models_gpu = opts.use_cuda
                           ? clone_model_to_gpus(model_cpu, opts.device_ids)
                           : std::vector<torch::jit::script::Module>{};
-    auto inputs = generate_inputs(opts.input_dims, opts.input_types);
+    auto inputs = generate_inputs(opts.inputs);
     auto output_refs = run_reference_inference(model_cpu, inputs);
 
     return {model_cpu, models_gpu, output_refs};

--- a/src/utils/client_utils.cpp
+++ b/src/utils/client_utils.cpp
@@ -51,8 +51,7 @@ pre_generate_inputs(const RuntimeConfig& opts, size_t num_inputs)
   std::vector<std::vector<torch::Tensor>> inputs;
   inputs.reserve(num_inputs);
   std::generate_n(std::back_inserter(inputs), num_inputs, [&]() {
-    return input_generator::generate_random_inputs(
-        opts.input_dims, opts.input_types);
+    return input_generator::generate_random_inputs(opts.inputs);
   });
   return inputs;
 }

--- a/src/utils/config_loader.cpp
+++ b/src/utils/config_loader.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <algorithm>
 
 #include "logger.hpp"
 #include "transparent_hash.hpp"
@@ -18,32 +19,44 @@ namespace {
 static auto
 parse_type_string(const std::string& type_str) -> at::ScalarType
 {
+  std::string key = type_str;
+  if (key.rfind("TYPE_", 0) == 0) {
+    key = key.substr(5);
+  }
+  std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+
   static const std::unordered_map<
       std::string, at::ScalarType, TransparentHash, std::equal_to<>>
       type_map = {
           {"float", at::kFloat},
           {"float32", at::kFloat},
+          {"fp32", at::kFloat},
           {"double", at::kDouble},
           {"float64", at::kDouble},
+          {"fp64", at::kDouble},
           {"half", at::kHalf},
           {"float16", at::kHalf},
+          {"fp16", at::kHalf},
           {"bfloat16", at::kBFloat16},
+          {"bf16", at::kBFloat16},
           {"int", at::kInt},
           {"int32", at::kInt},
-          {"long", at::kLong},
           {"int64", at::kLong},
-          {"short", at::kShort},
+          {"long", at::kLong},
           {"int16", at::kShort},
-          {"char", at::kChar},
+          {"short", at::kShort},
           {"int8", at::kChar},
-          {"byte", at::kByte},
+          {"char", at::kChar},
           {"uint8", at::kByte},
+          {"byte", at::kByte},
           {"bool", at::kBool},
           {"complex64", at::kComplexFloat},
           {"complex128", at::kComplexDouble},
       };
 
-  auto iter = type_map.find(type_str);
+  auto iter = type_map.find(key);
   if (iter == type_map.end()) {
     throw std::invalid_argument("Unsupported type: " + type_str);
   }
@@ -95,15 +108,34 @@ load_config(const std::string& path) -> RuntimeConfig
         cfg.use_cuda = true;
       }
     }
-    if (root["dims"]) {
-      for (const auto& dim_node : root["dims"]) {
-        cfg.input_dims.push_back(dim_node.as<std::vector<int64_t>>());
+    if (root["input"]) {
+      for (const auto& node : root["input"]) {
+        TensorConfig t{};
+        if (node["name"]) {
+          t.name = node["name"].as<std::string>();
+        }
+        if (node["dims"]) {
+          t.dims = node["dims"].as<std::vector<int64_t>>();
+        }
+        if (node["data_type"]) {
+          t.type = parse_type_string(node["data_type"].as<std::string>());
+        }
+        cfg.inputs.push_back(std::move(t));
       }
     }
-    if (root["types"]) {
-      for (const auto& type_node : root["types"]) {
-        cfg.input_types.push_back(
-            parse_type_string(type_node.as<std::string>()));
+    if (root["output"]) {
+      for (const auto& node : root["output"]) {
+        TensorConfig t{};
+        if (node["name"]) {
+          t.name = node["name"].as<std::string>();
+        }
+        if (node["dims"]) {
+          t.dims = node["dims"].as<std::vector<int64_t>>();
+        }
+        if (node["data_type"]) {
+          t.type = parse_type_string(node["data_type"].as<std::string>());
+        }
+        cfg.outputs.push_back(std::move(t));
       }
     }
     if (root["verbose"]) {
@@ -136,8 +168,8 @@ load_config(const std::string& path) -> RuntimeConfig
     if (root["use_cuda"]) {
       cfg.use_cuda = root["use_cuda"].as<bool>();
     }
-    cfg.max_message_bytes = compute_max_message_bytes(
-        cfg.max_batch_size, cfg.input_dims, cfg.input_types);
+    cfg.max_message_bytes =
+        compute_max_message_bytes(cfg.max_batch_size, cfg.inputs);
   }
   catch (const std::exception& e) {
     log_error(std::string("Failed to load config: ") + e.what());

--- a/src/utils/input_generator.hpp
+++ b/src/utils/input_generator.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "exceptions.hpp"
+#include "runtime_config.hpp"
 
 namespace starpu_server::input_generator {
 
@@ -70,17 +71,15 @@ generate_random_tensor(
 // - dims and types must match model input signature
 // -----------------------------------------------------------------------------
 inline auto
-generate_random_inputs(
-    const std::vector<std::vector<int64_t>>& dims,
-    const std::vector<at::ScalarType>& types) -> std::vector<torch::Tensor>
+generate_random_inputs(const std::vector<TensorConfig>& tensors)
+    -> std::vector<torch::Tensor>
 {
   std::vector<torch::Tensor> inputs;
-  inputs.reserve(dims.size());
+  inputs.reserve(tensors.size());
 
-  for (size_t i = 0; i < dims.size(); ++i) {
-    const auto& dim = dims[i];
-    const at::ScalarType type = (i < types.size()) ? types[i] : at::kFloat;
-    inputs.push_back(generate_random_tensor(dim, type, i));
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    const auto& t = tensors[i];
+    inputs.push_back(generate_random_tensor(t.dims, t.type, i));
   }
 
   return inputs;

--- a/tests/common/test_inference_runner.hpp
+++ b/tests/common/test_inference_runner.hpp
@@ -102,11 +102,10 @@ run_reference_inference(
 }
 
 inline auto
-generate_inputs(
-    const std::vector<std::vector<int64_t>>& dims,
-    const std::vector<at::ScalarType>& types) -> std::vector<torch::Tensor>
+generate_inputs(const std::vector<TensorConfig>& tensors)
+    -> std::vector<torch::Tensor>
 {
-  return input_generator::generate_random_inputs(dims, types);
+  return input_generator::generate_random_inputs(tensors);
 }
 
 auto load_model_and_reference_output(const RuntimeConfig& opts)

--- a/tests/common/test_warmup_runner.hpp
+++ b/tests/common/test_warmup_runner.hpp
@@ -37,8 +37,7 @@ struct WarmupRunnerTestFixture {
   void init(bool use_cuda = false)
   {
     opts = starpu_server::RuntimeConfig{};
-    opts.input_dims = {{1}};
-    opts.input_types = {at::kFloat};
+    opts.inputs = {{"input0", {1}, at::kFloat}};
     opts.use_cuda = use_cuda;
 
     starpu = std::make_unique<starpu_server::StarPUSetup>(opts);

--- a/tests/integration/core/integration_inference_runner.cpp
+++ b/tests/integration/core/integration_inference_runner.cpp
@@ -33,8 +33,7 @@ TEST(InferenceRunner_Integration, LoadModelAndReferenceOutputCPU)
 
   starpu_server::RuntimeConfig opts;
   opts.model_path = file.string();
-  opts.input_dims = {kShape4};
-  opts.input_types = kTypesFloat;
+  opts.inputs = {{"input0", kShape4, at::kFloat}};
   opts.device_ids = {kDeviceId0};
   opts.use_cuda = false;
 
@@ -44,8 +43,7 @@ TEST(InferenceRunner_Integration, LoadModelAndReferenceOutputCPU)
   EXPECT_TRUE(gpu_models.empty());
 
   torch::manual_seed(42);
-  auto inputs =
-      starpu_server::generate_inputs(opts.input_dims, opts.input_types);
+  auto inputs = starpu_server::generate_inputs(opts.inputs);
   ASSERT_EQ(refs.size(), 1U);
   EXPECT_TRUE(torch::allclose(refs[0], inputs[0] * 2));
 
@@ -60,8 +58,7 @@ TEST(InferenceRunner_Integration, LoadModelAndReferenceOutputTuple)
 
   starpu_server::RuntimeConfig opts;
   opts.model_path = file.string();
-  opts.input_dims = {kShape2};
-  opts.input_types = kTypesFloat;
+  opts.inputs = {{"input0", kShape2, at::kFloat}};
   opts.device_ids = {kDeviceId0};
   opts.use_cuda = false;
 
@@ -71,8 +68,7 @@ TEST(InferenceRunner_Integration, LoadModelAndReferenceOutputTuple)
   EXPECT_TRUE(gpu_models.empty());
 
   torch::manual_seed(1);
-  auto inputs =
-      starpu_server::generate_inputs(opts.input_dims, opts.input_types);
+  auto inputs = starpu_server::generate_inputs(opts.inputs);
   ASSERT_EQ(refs.size(), 2U);
   EXPECT_TRUE(torch::allclose(refs[0], inputs[0]));
   EXPECT_TRUE(torch::allclose(refs[1], inputs[0] + 1));
@@ -88,8 +84,7 @@ TEST(InferenceRunner_Integration, LoadModelAndReferenceOutputTensorList)
 
   starpu_server::RuntimeConfig opts;
   opts.model_path = file.string();
-  opts.input_dims = {kShape2};
-  opts.input_types = kTypesFloat;
+  opts.inputs = {{"input0", kShape2, at::kFloat}};
   opts.device_ids = {kDeviceId0};
   opts.use_cuda = false;
 
@@ -99,8 +94,7 @@ TEST(InferenceRunner_Integration, LoadModelAndReferenceOutputTensorList)
   EXPECT_TRUE(gpu_models.empty());
 
   torch::manual_seed(2);
-  auto inputs =
-      starpu_server::generate_inputs(opts.input_dims, opts.input_types);
+  auto inputs = starpu_server::generate_inputs(opts.inputs);
   ASSERT_EQ(refs.size(), 2U);
   EXPECT_TRUE(torch::allclose(refs[0], inputs[0]));
   EXPECT_TRUE(torch::allclose(refs[1], inputs[0] + 1));

--- a/tests/integration/core/integration_run_inference_loop.cpp
+++ b/tests/integration/core/integration_run_inference_loop.cpp
@@ -20,8 +20,7 @@ run_add_one_integration_test(
   model.save(model_path.string());
   starpu_server::RuntimeConfig opts;
   opts.model_path = model_path.string();
-  opts.input_dims = {{1}};
-  opts.input_types = {at::kFloat};
+  opts.inputs = {{"input0", {1}, at::kFloat}};
   opts.iterations = 1;
   opts.use_cpu = use_cpu;
   opts.use_cuda = use_cuda;

--- a/tests/integration/test_run_inference_loop.cpp
+++ b/tests/integration/test_run_inference_loop.cpp
@@ -20,8 +20,7 @@ run_add_one_integration_test(
   model.save(model_path.string());
   starpu_server::RuntimeConfig opts;
   opts.model_path = model_path.string();
-  opts.input_dims = {{1}};
-  opts.input_types = {at::kFloat};
+  opts.inputs = {{"input0", {1}, at::kFloat}};
   opts.iterations = 1;
   opts.use_cpu = use_cpu;
   opts.use_cuda = use_cuda;

--- a/tests/unit/cli/unit_cli.cpp
+++ b/tests/unit/cli/unit_cli.cpp
@@ -13,10 +13,9 @@ TEST(ArgsParser_Unit, ParsesRequiredOptions)
        "float"});
   ASSERT_TRUE(opts.valid);
   EXPECT_EQ(opts.model_path, "model.pt");
-  ASSERT_EQ(opts.input_dims.size(), 1U);
-  EXPECT_EQ(opts.input_dims[0], (std::vector<int64_t>{1, 3, 224, 224}));
-  ASSERT_EQ(opts.input_types.size(), 1U);
-  EXPECT_EQ(opts.input_types[0], at::kFloat);
+  ASSERT_EQ(opts.inputs.size(), 1U);
+  EXPECT_EQ(opts.inputs[0].dims, (std::vector<int64_t>{1, 3, 224, 224}));
+  EXPECT_EQ(opts.inputs[0].type, at::kFloat);
 }
 
 TEST(ArgsParser_Unit, ParsesAllOptions)
@@ -59,12 +58,11 @@ TEST(ArgsParser_Unit, ParsesAllOptions)
   EXPECT_FALSE(opts.use_cpu);
   EXPECT_TRUE(opts.use_cuda);
   ASSERT_EQ(opts.device_ids, (std::vector<int>{0, 1}));
-  ASSERT_EQ(opts.input_dims.size(), 2U);
-  EXPECT_EQ(opts.input_dims[0], (std::vector<int64_t>{1, 3, 224, 224}));
-  EXPECT_EQ(opts.input_dims[1], (std::vector<int64_t>{2, 1}));
-  ASSERT_EQ(opts.input_types.size(), 2U);
-  EXPECT_EQ(opts.input_types[0], at::kFloat);
-  EXPECT_EQ(opts.input_types[1], at::kInt);
+  ASSERT_EQ(opts.inputs.size(), 2U);
+  EXPECT_EQ(opts.inputs[0].dims, (std::vector<int64_t>{1, 3, 224, 224}));
+  EXPECT_EQ(opts.inputs[1].dims, (std::vector<int64_t>{2, 1}));
+  EXPECT_EQ(opts.inputs[0].type, at::kFloat);
+  EXPECT_EQ(opts.inputs[1].type, at::kInt);
 }
 
 TEST(ArgsParser_Unit, VerboseLevels)

--- a/tests/unit/core/robustness/edgecases_inference_runner.cpp
+++ b/tests/unit/core/robustness/edgecases_inference_runner.cpp
@@ -36,8 +36,7 @@ TEST(InferenceRunner_Robustesse, LoadModelAndReferenceOutputUnsupported)
 
   starpu_server::RuntimeConfig opts;
   opts.model_path = file.string();
-  opts.input_dims = {kShape1};
-  opts.input_types = kTypesFloat;
+  opts.inputs = {{"input0", kShape1, at::kFloat}};
   opts.device_ids = {0};
   opts.use_cuda = false;
 

--- a/tests/unit/core/robustness/edgecases_inference_runner_helpers.cpp
+++ b/tests/unit/core/robustness/edgecases_inference_runner_helpers.cpp
@@ -23,8 +23,7 @@ TEST(InferenceRunnerHelpers_Robustesse, LoadModelAndReferenceOutputCorruptFile)
 
   starpu_server::RuntimeConfig opts;
   opts.model_path = tmp_path.string();
-  opts.input_dims = {{1}};
-  opts.input_types = {torch::kFloat32};
+  opts.inputs = {{"input0", {1}, at::kFloat}};
 
   starpu_server::CaptureStream capture{std::cerr};
   auto [cpu_model, gpu_models, refs] =
@@ -56,8 +55,7 @@ TEST_P(LoadModelAndReferenceOutputError_Robustesse, MissingFile)
 {
   starpu_server::RuntimeConfig opts;
   opts.model_path = "nonexistent_model.pt";
-  opts.input_dims = {{1}};
-  opts.input_types = {GetParam()};
+  opts.inputs = {{"input0", {1}, GetParam()}};
   starpu_server::CaptureStream capture{std::cerr};
   auto [cpu_model, gpu_models, refs] =
       starpu_server::load_model_and_reference_output(opts);

--- a/tests/unit/core/unit_inference_runner.cpp
+++ b/tests/unit/core/unit_inference_runner.cpp
@@ -79,8 +79,14 @@ TEST(InferenceJob_Unit, SettersGettersAndCallback)
 TEST(InferenceRunnerUtils_Unit, GenerateInputsShapeAndType)
 {
   const std::vector<std::vector<int64_t>> shapes{kShape2x3, kShape1};
+  std::vector<starpu_server::TensorConfig> cfgs;
+  cfgs.reserve(shapes.size());
+  for (size_t i = 0; i < shapes.size(); ++i) {
+    cfgs.push_back({
+        std::string("input") + std::to_string(i), shapes[i], kTypesFloatInt[i]});
+  }
   torch::manual_seed(0);
-  auto tensors = starpu_server::generate_inputs(shapes, kTypesFloatInt);
+  auto tensors = starpu_server::generate_inputs(cfgs);
   ASSERT_EQ(tensors.size(), 2U);
   EXPECT_EQ(
       tensors[0].sizes(), (torch::IntArrayRef{kShape2x3[0], kShape2x3[1]}));

--- a/tests/unit/utils/unit_client_utils.cpp
+++ b/tests/unit/utils/unit_client_utils.cpp
@@ -55,14 +55,16 @@ TEST(ClientUtils, CreateJobProducesExpectedFields)
 TEST(ClientUtils, PreGenerateInputsProducesValidTensors)
 {
   starpu_server::RuntimeConfig opts;
-  opts.input_dims = {{2, 3}, {1}};
-  opts.input_types = {at::kFloat, at::kInt};
+  opts.inputs = {
+      {"input0", {2, 3}, at::kFloat},
+      {"input1", {1}, at::kInt},
+  };
   const size_t batch_size = 3;
   auto batches =
       starpu_server::client_utils::pre_generate_inputs(opts, batch_size);
   ASSERT_EQ(batches.size(), batch_size);
   for (const auto& tensors : batches) {
-    ASSERT_EQ(tensors.size(), opts.input_dims.size());
+    ASSERT_EQ(tensors.size(), opts.inputs.size());
     EXPECT_EQ(tensors[0].sizes(), (torch::IntArrayRef{2, 3}));
     EXPECT_EQ(tensors[0].dtype(), at::kFloat);
     EXPECT_EQ(tensors[1].sizes(), (torch::IntArrayRef{1}));


### PR DESCRIPTION
## Summary
- introduce `TensorConfig` struct and store model inputs/outputs in runtime configuration
- parse YAML `input`/`output` entries with name, data type and dimensions
- update CLI, helpers and tests to operate on `TensorConfig` and new layout
- add resnet18 example config using new schema

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Torch")*


------
https://chatgpt.com/codex/tasks/task_e_68a85c74797c8323a6eb724c9ba3bdc6